### PR TITLE
Enable agruments for election entry (ve)

### DIFF
--- a/mytoncore.py
+++ b/mytoncore.py
@@ -749,7 +749,7 @@ class MyTonCore():
 				return
 
 			# Limit stake to maximum available amount minus 10 (for transaction fees)
-			if stake > account.balance:
+			if stake > account.balance - 10:
 				stake = account.balance - 10
 
 			if minStake > stake:

--- a/mytoncore.py
+++ b/mytoncore.py
@@ -735,6 +735,9 @@ class MyTonCore():
 			local.AddLog("You don't have enough grams. Minimum stake: " + str(minStake), "debug")
 			return
 
+		# Default rate multiplier
+		rateMultiplier = 1
+
 		# Check if optional arguments have been passed to us
 		if args:
 			m = re.match(r"(\d+\.?\d?)\%", args[0])
@@ -765,8 +768,6 @@ class MyTonCore():
 				stake = int(account.balance*0.99/2)
 			if len(validators) > 0 or (stake is not None and stake < minStake):
 				stake = int(account.balance*0.99)
-
-			rateMultiplier = 1
 
 		# Calculate endWorkTime
 		validatorsElectedFor = self.GetValidatorsElectedFor()

--- a/mytoncore.py
+++ b/mytoncore.py
@@ -740,13 +740,14 @@ class MyTonCore():
 
 		# Check if optional arguments have been passed to us
 		if args:
-			m = re.match(r"(\d+\.?\d?)\%", args[0])
+			desiredStake = args[0]
+			m = re.match(r"(\d+\.?\d?)\%", desiredStake)
 			if m:
 				# Stake was in percent
 				stake = round((account.balance / 100) * float(m.group(1)))
 			elif desiredStake.isnumeric():
 				# Stake was a number
-				stake = int(args[0])
+				stake = int(desiredStake)
 			else:
 				local.AddLog("Specified stake must be a percentage or whole number", "error")
 				return

--- a/mytonctrl.py
+++ b/mytonctrl.py
@@ -665,7 +665,7 @@ def VoteElectionEntry(args):
 	if ton.validatorWalletName is None:
 		ColorPrint("{red}You are not a validator, or this utility is not configured correctly.{endc}")
 	ton.ReturnStake()
-	ton.ElectionEntry()
+	ton.ElectionEntry(args)
 	ColorPrint("VoteElectionEntry - {green}OK{endc}")
 #end define
 


### PR DESCRIPTION
This adjustment allows input of two arguments to ve function:

Desired stake size in percent of available funds or fixed number
Multiplier to adjust automatically calculated rate (float)

Examples:

ve 100%
Will participate in elections using 100% of account funds (minus 10 grams for transaction fees).

ve 60000 0.5
Will participate in elections using 60000 grams (if available) and rate set to 0.5 of what it normally would be.
