### PR TITLE
Allow optional definition of config file and wallets path

### DIFF
--- a/mytoncore.py
+++ b/mytoncore.py
@@ -138,6 +138,7 @@ class Domain(dict):
 class MyTonCore():
 	def __init__(self):
 		self.walletsDir = None
+		self.dbFile = None
 		self.adnlAddr = None
 		self.tempDir = None
 		self.validatorWalletName = None
@@ -146,7 +147,6 @@ class MyTonCore():
 		self.validatorConsole = ValidatorConsole()
 		self.fift = Fift()
 
-		local.dbLoad()
 		self.Refresh()
 		self.Init()
 	#end define
@@ -157,7 +157,14 @@ class MyTonCore():
 	#end define
 
 	def Refresh(self):
-		self.walletsDir = dir(local.buffer.get("myWorkDir") + "wallets")
+		if self.dbFile:
+			local.dbLoad(self.dbFile)
+		else:
+			local.dbLoad()
+
+		if not self.walletsDir:
+			self.walletsDir = dir(local.buffer.get("myWorkDir") + "wallets")
+
 		self.tempDir = local.buffer.get("myTempDir")
 
 		self.adnlAddr = local.db.get("adnlAddr")

--- a/mytonctrl.py
+++ b/mytonctrl.py
@@ -5,13 +5,16 @@ from mypylib.mypylib import *
 from mypyconsole.mypyconsole import MyPyConsole
 from mytoncore import *
 import platform
+import sys, getopt, os
+
+
 
 local = MyPyClass(__file__)
 console = MyPyConsole()
 ton = MyTonCore()
 # Must control: /var/ton-work/db/keyring/
 
-def Init():
+def Init(argv):
 	# Create user console
 	console.name = "MyTonCtrl"
 	console.AddItem("upgrade", RunUpdater, "Check and install MyTonCtrl updates")
@@ -54,6 +57,29 @@ def Init():
 
 	console.AddItem("test", Test, "")
 
+	# Process input parameters
+	opts, args = getopt.getopt(argv,"hc:w:",["config=","wallets="])
+	for opt, arg in opts:
+		if opt == '-h':
+			print ('mytonctrl.py -c <configfile> -w <wallets>')
+			sys.exit()
+		elif opt in ("-c", "--config"):
+			configfile = arg
+			if not os.access(configfile, os.R_OK):
+				print ("Configuration file " + configfile + " could not be opened")
+				sys.exit()
+
+			ton.dbFile = configfile
+			ton.Refresh()
+		elif opt in ("-w", "--wallets"):
+			wallets = arg
+			if not os.access(wallets, os.R_OK):
+				print ("Wallets path " + wallets  + " could not be opened")
+				sys.exit()
+			elif not os.path.isdir(wallets):
+				print ("Wallets path " + wallets  + " is not a directory")
+				sys.exit()
+			ton.walletsDir = wallets
 
 	local.db["config"]["logLevel"] = "debug"
 	local.db["config"]["isLocaldbSaving"] = True
@@ -702,6 +728,6 @@ def secondsToText(secs):
 ###
 
 if __name__ == "__main__":
-	Init()
+	Init(sys.argv[1:])
 	console.Run()
 #end if


### PR DESCRIPTION
This PR ehnances myconctrl with ability to accept two _optional_ parameters:

-c **_configFile_** 
-w **_walletsPath_**

Where 

**_configFile_** is a JSON file instead of fixed $HOME/.local/share/mytoncore/mytoncore.db
**_walletsPath_** is a path with wallets / keys instead of fixed $HOME/.local/share/mytoncore/wallets

**Attention**, this PR also requires merge of following PR: https://github.com/igroman787/mypylib/pull/3 and update of mypylib submodule