### PR TITLE
Restrict imported wallet key permissions

### DIFF
--- a/modules/wallet.py
+++ b/modules/wallet.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import os
+import tempfile
 
 from modules.module import MtcModule
 from mypylib.mypylib import color_print, print_table, parse
@@ -34,6 +35,13 @@ class WalletModule(MtcModule):
                     except Exception:
                         pass
             index = max(index_list) + 1
+            index_str = str(index).rjust(3, '0')
+            wallet_name = wallet_prefix + index_str
+        while (
+            os.path.lexists(self.ton.walletsDir + wallet_name + ".addr")
+            or os.path.lexists(self.ton.walletsDir + wallet_name + ".pk")
+        ):
+            index += 1
             index_str = str(index).rjust(3, '0')
             wallet_name = wallet_prefix + index_str
         return wallet_name
@@ -121,12 +129,49 @@ class WalletModule(MtcModule):
         addr_bytes = self.ton.addr_b64_to_bytes(addr_b64)
         pk_bytes = base64.b64decode(key)
         wallet_name = self.generate_wallet_name()
-        wallet_path = self.ton.walletsDir + wallet_name
-        with open(wallet_path + ".addr", 'wb') as file:
-            file.write(addr_bytes)
-        with open(wallet_path + ".pk", 'wb') as file:
-            file.write(pk_bytes)
-        return wallet_name
+        while True:
+            wallet_path = self.ton.walletsDir + wallet_name
+            pk_path = wallet_path + ".pk"
+            addr_path = wallet_path + ".addr"
+            addr_fd = pk_fd = None
+            addr_temp_path = pk_temp_path = None
+            pk_linked = False
+            try:
+                addr_fd, addr_temp_path = tempfile.mkstemp(
+                    suffix=".addr", prefix=f".{wallet_name}.", dir=self.ton.walletsDir
+                )
+                pk_fd, pk_temp_path = tempfile.mkstemp(
+                    suffix=".pk", prefix=f".{wallet_name}.", dir=self.ton.walletsDir
+                )
+                addr_file = os.fdopen(addr_fd, 'wb')
+                addr_fd = None
+                with addr_file:
+                    addr_file.write(addr_bytes)
+                os.fchmod(pk_fd, 0o600)
+                pk_file = os.fdopen(pk_fd, 'wb')
+                pk_fd = None
+                with pk_file:
+                    pk_file.write(pk_bytes)
+                os.link(pk_temp_path, pk_path)
+                pk_linked = True
+                os.link(addr_temp_path, addr_path)
+            except FileExistsError:
+                if pk_linked:
+                    os.remove(pk_path)
+                wallet_name = self.generate_wallet_name()
+            except Exception:
+                if pk_linked:
+                    os.remove(pk_path)
+                raise
+            else:
+                return wallet_name
+            finally:
+                for fd in (addr_fd, pk_fd):
+                    if fd is not None:
+                        os.close(fd)
+                for path in (addr_temp_path, pk_temp_path):
+                    if path is not None and os.path.lexists(path):
+                        os.remove(path)
 
     def import_wallet(self, args):
         if not check_usage_two_args("iw", args):

--- a/mytoncore/mytoncore.py
+++ b/mytoncore/mytoncore.py
@@ -75,7 +75,8 @@ class MyTonCore:
 		self.poolsDir = self.local.my_work_dir + "pools/"
 		self.tempDir = self.local.my_temp_dir
 
-		os.makedirs(self.walletsDir, exist_ok=True)
+		os.makedirs(self.walletsDir, mode=0o700, exist_ok=True)
+		os.chmod(self.walletsDir, 0o700)
 		os.makedirs(self.contractsDir, exist_ok=True)
 		os.makedirs(self.poolsDir, exist_ok=True)
 

--- a/mytonctrl/__main__.py
+++ b/mytonctrl/__main__.py
@@ -80,7 +80,7 @@ def _main():
         mytoncore_local.load_db()
     ton = MyTonCore(mytoncore_local)
     if args.wallets is not None:
-        ton.walletsDir = args.wallets
+        ton.walletsDir = os.path.join(args.wallets, '')
 
     if args.cmd is None:
         try:

--- a/tests/integration/test_init_argv.py
+++ b/tests/integration/test_init_argv.py
@@ -112,7 +112,7 @@ def test_init_with_wallets_arg_sets_ton_walletsdir(
     main_module._main()
 
     assert len(captured) == 1
-    assert captured[0].walletsDir == wallets_dir
+    assert captured[0].walletsDir == os.path.join(wallets_dir, "")
 
 
 def test_init_with_unreadable_config_exits(

--- a/tests/unit/test_wallet.py
+++ b/tests/unit/test_wallet.py
@@ -1,11 +1,14 @@
+import base64
 import os
+import stat
 import struct
 import types
+
 import pytest
 
+from modules.wallet import WalletModule
 from mytoncore.models import Account
 from mytoncore.mytoncore import MyTonCore
-from modules.wallet import WalletModule
 
 
 @pytest.fixture
@@ -89,6 +92,99 @@ def test_generate_wallet_name_and_list(ton: MyTonCore, module: WalletModule, tmp
 
     assert ton.GetWalletsNameList() == ['wallet_001']
     assert module.generate_wallet_name() == 'wallet_002'
+
+
+@pytest.mark.parametrize('umask', [0o000, 0o022])
+def test_do_import_wallet_restricts_private_key_permissions(ton: MyTonCore, module: WalletModule, monkeypatch, umask):
+    monkeypatch.setattr(ton, 'addr_b64_to_bytes', lambda _: b'\x00' * 36)
+    private_key = b'\x01' * 32
+    old_umask = os.umask(umask)
+    try:
+        name = module.do_import_wallet('address', base64.b64encode(private_key).decode())
+    finally:
+        os.umask(old_umask)
+
+    private_key_path = os.path.join(ton.walletsDir, name + '.pk')
+    assert stat.S_IMODE(os.stat(private_key_path).st_mode) == 0o600
+    with open(private_key_path, 'rb') as file:
+        assert file.read() == private_key
+
+
+def test_do_import_wallet_creates_private_key_with_restricted_permissions(ton: MyTonCore, module: WalletModule, monkeypatch):
+    monkeypatch.setattr(ton, 'addr_b64_to_bytes', lambda _: b'\x00' * 36)
+    original_fdopen = os.fdopen
+
+    def check_private_key_permissions(fd, mode):
+        assert stat.S_IMODE(os.fstat(fd).st_mode) == 0o600
+        return original_fdopen(fd, mode)
+
+    monkeypatch.setattr(os, 'fdopen', check_private_key_permissions)
+    module.do_import_wallet('address', base64.b64encode(b'\x01' * 32).decode())
+
+
+def test_do_import_wallet_does_not_overwrite_partial_wallet(ton: MyTonCore, module: WalletModule, monkeypatch):
+    monkeypatch.setattr(ton, 'addr_b64_to_bytes', lambda _: b'\x00' * 36)
+    existing_private_key_path = os.path.join(ton.walletsDir, 'wallet_001.pk')
+    with open(existing_private_key_path, 'wb') as file:
+        file.write(b'old key')
+
+    name = module.do_import_wallet('address', base64.b64encode(b'\x01' * 32).decode())
+
+    assert name == 'wallet_002'
+    with open(existing_private_key_path, 'rb') as file:
+        assert file.read() == b'old key'
+
+
+def test_do_import_wallet_removes_temporary_files_on_error(ton: MyTonCore, module: WalletModule, monkeypatch):
+    monkeypatch.setattr(ton, 'addr_b64_to_bytes', lambda _: b'\x00' * 36)
+
+    def fail_link(source, destination):
+        raise OSError('link failed')
+
+    monkeypatch.setattr(os, 'link', fail_link)
+
+    with pytest.raises(OSError, match='link failed'):
+        module.do_import_wallet('address', base64.b64encode(b'\x01' * 32).decode())
+
+    assert os.listdir(ton.walletsDir) == []
+
+
+def test_do_import_wallet_removes_private_key_when_address_publication_fails(ton: MyTonCore, module: WalletModule, monkeypatch):
+    monkeypatch.setattr(ton, 'addr_b64_to_bytes', lambda _: b'\x00' * 36)
+    original_link = os.link
+
+    def fail_address_link(source, destination):
+        if destination.endswith('.addr'):
+            raise OSError('address link failed')
+        return original_link(source, destination)
+
+    monkeypatch.setattr(os, 'link', fail_address_link)
+
+    with pytest.raises(OSError, match='address link failed'):
+        module.do_import_wallet('address', base64.b64encode(b'\x01' * 32).decode())
+
+    assert os.listdir(ton.walletsDir) == []
+
+
+@pytest.mark.parametrize('umask', [0o000, 0o022])
+def test_wallets_directory_is_private(local, umask):
+    old_umask = os.umask(umask)
+    try:
+        ton = MyTonCore(local)
+    finally:
+        os.umask(old_umask)
+
+    assert stat.S_IMODE(os.stat(ton.walletsDir).st_mode) == 0o700
+
+
+def test_existing_wallets_directory_is_private(local):
+    wallets_dir = os.path.join(local.my_work_dir, 'wallets')
+    os.makedirs(wallets_dir, mode=0o755)
+    os.chmod(wallets_dir, 0o755)
+
+    ton = MyTonCore(local)
+
+    assert stat.S_IMODE(os.stat(ton.walletsDir).st_mode) == 0o700
 
 
 def test_do_move_coins(ton: MyTonCore, module: WalletModule, monkeypatch, tmp_path):


### PR DESCRIPTION
Fixes #554.

Imported keys are written with mode `0600`, and the default wallet directory is enforced as `0700`. The import path publishes completed files without replacing incomplete wallet files.

Tests:
- `.venv/bin/pytest -k "not test_download_archive_blocks"` (198 passed, 1 deselected; macOS has no `systemctl`)
- `.venv/bin/ruff check .`
- `.venv/bin/pyright --pythonpath .venv/bin/python`